### PR TITLE
postの各アクションにフラッシュメッセージを定義

### DIFF
--- a/app/assets/stylesheets/_flash.scss
+++ b/app/assets/stylesheets/_flash.scss
@@ -1,15 +1,18 @@
-.notice {
+.flash {
   position: fixed;
   top: 0;
   width: 100%;
   height: 40px;
-  background: rgba(247, 247, 247, 0.3);
   text-align: center;
   font-size: 16px;
   line-height: 40px;
-}
 
-.alert {
-  color: white;
-  background-color: red;
+  .notice {
+    background: rgba(247, 247, 247, 0.3);
+  }
+
+  .alert {
+    background: rgba(255, 0, 0, 0.4);
+  }
+
 }

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -9,7 +9,7 @@ class PostsController < ApplicationController
 
   def create
     Post.create(post_params)
-    redirect_to action: :index
+    redirect_to posts_url, notice: "投稿しました。"
   end
 
   def show
@@ -23,13 +23,13 @@ class PostsController < ApplicationController
   def update
     post = Post.find(params[:id])
     post.update(post_params)
-    redirect_to action: :index
+    redirect_to posts_url, notice: "更新しました。"
   end
 
   def destroy
     post = Post.find(params[:id])
     post.destroy
-    redirect_to action: :index
+    redirect_to posts_url, alert: "削除しました。"
   end
 
   private

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,4 +1,6 @@
 class PostsController < ApplicationController
+  before_action :set_post, only: [:show, :edit, :update, :destroy]
+
   def index
     @posts = Post.all
   end
@@ -13,26 +15,26 @@ class PostsController < ApplicationController
   end
 
   def show
-    @post = Post.find(params[:id])
   end
 
   def edit
-    @post = Post.find(params[:id])
   end
 
   def update
-    post = Post.find(params[:id])
-    post.update(post_params)
+    @post.update(post_params)
     redirect_to posts_url, notice: "更新しました。"
   end
 
   def destroy
-    post = Post.find(params[:id])
-    post.destroy
+    @post.destroy
     redirect_to posts_url, alert: "削除しました。"
   end
 
   private
+
+  def set_post
+    @post = Post.find(params[:id])
+  end
 
   def post_params
     params.require(:post).permit(:title, :language, :code)

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,6 +12,7 @@
 
   <body>
     <%= render 'shared/header' %>
+    <%= render 'shared/flash_messages' %>
     <%= yield %>
   </body>
 </html>

--- a/app/views/shared/_flash_messages.html.erb
+++ b/app/views/shared/_flash_messages.html.erb
@@ -1,3 +1,5 @@
-<% flash.each do |key, value| %>
-  <%= content_tag :div, value, class: key %>
-<% end %>
+<div class="flash">
+  <% flash.each do |flash_type, msg| %>
+    <%= content_tag :p, msg, class: flash_type %>
+  <% end %>
+</div>


### PR DESCRIPTION
## 概要
postsコントローラーにフラッシュメッセージを定義

### 内容
- `posts`コントローラーの`create` `update` `destroy` アクションで
リダイレクト時にフラッシュメッセージを定義
- `posts`コントローラー内の共通部分を`before_action`で共通化