### PR TITLE
usersテーブルにprofileを追加

### DIFF
--- a/app/assets/stylesheets/_user-auth.scss
+++ b/app/assets/stylesheets/_user-auth.scss
@@ -27,7 +27,8 @@
         display: none;
       }
 
-      input {
+      input,
+      textarea {
         box-sizing: border-box;
         width: 100%;
       }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,7 +3,7 @@ class ApplicationController < ActionController::Base
 
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
-    devise_parameter_sanitizer.permit(:account_update, keys: [:name, :image])
+    devise_parameter_sanitizer.permit(:account_update, keys: [:name, :image, :profile])
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,7 +4,9 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 
-  has_many :posts
-
+  validates :name, presence: true
+  validates :profile, length: { maximum: 100 }
   mount_uploader :image, ImageUploader
+
+  has_many :posts
 end

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -29,9 +29,9 @@ class ImageUploader < CarrierWave::Uploader::Base
   # end
 
   # Create different versions of your uploaded files:
-  version :thumb do
-    process resize_to_fit: [64, 64]
-  end
+  # version :thumb do
+  #   process resize_to_fit: [64, 64]
+  # end
 
   process resize_to_limit: [128, 128]
 

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -5,7 +5,7 @@
   <div class="posts__list">
     <% @posts.each do |post| %>
       <div class="posts__list--item">
-        <%= image_tag post.user.image.thumb.url, class: "icon" %>
+        <%= image_tag post.user.image.url, class: "icon" %>
         <div class="body">
           <%= link_to post.title, post, class: "title" %>
         </div>

--- a/app/views/users/registrations/edit.html.erb
+++ b/app/views/users/registrations/edit.html.erb
@@ -19,6 +19,11 @@
       </div>
 
       <div class="user-auth__form-field">
+        <%= f.label :profile %><br />
+        <%= f.text_area :profile, autocomplete: "profile", size: '30x10', placeholder: "プロフィール", maxlength: '100' %>
+      </div>
+
+      <div class="user-auth__form-field">
         <%= f.label :email %><br />
         <%= f.email_field :email, autofocus: true, autocomplete: "email", placeholder: "メールアドレス", required: true, maxlength: '100' %>
       </div>

--- a/db/migrate/20200831160351_add_profile_to_users.rb
+++ b/db/migrate/20200831160351_add_profile_to_users.rb
@@ -1,0 +1,5 @@
+class AddProfileToUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :profile, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_23_113627) do
+ActiveRecord::Schema.define(version: 2020_08_31_160351) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -34,6 +34,7 @@ ActiveRecord::Schema.define(version: 2020_08_23_113627) do
     t.datetime "updated_at", precision: 6, null: false
     t.string "name"
     t.string "image"
+    t.text "profile"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
## 概要
`users`テーブルに`profile`カラムを追加し、
プロフィール文を追加できるように実装

### 内容
- `users`テーブルに`profile`カラムを追加
- ストロングパラメーターに`profile`を追加
- `name`と`profile`にバリデーションを追加
- フォームに`profile`の`textarea`を追加

#### 備考

- サムネイル画像を使用しないように変更