### PR TITLE
プロフィール画面とプロフィール変更画面のレイアウトを変更

### DIFF
--- a/app/assets/stylesheets/_header.scss
+++ b/app/assets/stylesheets/_header.scss
@@ -6,7 +6,7 @@
   align-items: center;
   justify-content: space-between;
   padding: 20px 30px;
-  background: skyblue;
+  background: #3da9fc;
 
   & a:hover {
     text-decoration: none;

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -2,7 +2,5 @@
 @import "base";
 @import "header";
 @import "flash";
-@import "users/user-auth";
-@import "users/user-show";
-@import "posts/posts";
-@import "posts/post-form";
+@import "users/*";
+@import "posts/*";

--- a/app/assets/stylesheets/users/_user-show.scss
+++ b/app/assets/stylesheets/users/_user-show.scss
@@ -11,8 +11,8 @@
       margin-bottom: 10px;
 
       .icon {
-        width: 120px;
-        height: 120px;
+        width: 150px;
+        height: 150px;
         border-radius: 50%;
         box-shadow: 0 0 6px gray;
       }
@@ -32,12 +32,13 @@
     .area__button {
       text-align: center;
 
-      .edit {
+      .btn {
         text-decoration: none;
-        font-size: 18px;
-        padding: 10px;
+        font-size: 16px;
+        padding: 14px 26px;
         color: #fffffe;
         background: #5f6c7b;
+        border-radius: 3px;
       }
     }
   }

--- a/app/assets/stylesheets/users/_user.edit.scss
+++ b/app/assets/stylesheets/users/_user.edit.scss
@@ -1,0 +1,109 @@
+.user-edit {
+
+  .user-edit__main {
+    margin: 30px auto;
+    width: 450px;
+    padding: 30px;
+    background: white;
+
+    .form {
+      margin: 20px 0;
+
+      input,
+      textarea {
+        width: 100%;
+        padding: 10px;
+        font-size: 20px;
+        box-sizing: border-box;
+      }
+
+      .area-image {
+        text-align: center;
+        margin-bottom: 20px;
+
+        .icon {
+          width: 150px;
+          height: 150px;
+          border-radius: 50%;
+          box-shadow: 0 0 8px gray;
+        }
+      }
+
+      .image-field {
+        margin-bottom: 30px;
+
+        .btn {
+          display: block;
+          text-align: center;
+          border-radius: 3px;
+          width: 50%;
+          margin: 0 auto;
+          padding: 15px 0;
+          color: #fffffe;
+          background: #5f6c7b;
+
+          &:hover {
+            cursor: pointer;
+          }
+        }
+
+        input {
+          display: none;
+        }
+      }
+
+      .name-field {
+        margin: 0 20px 20px;
+      }
+
+      .profile-field {
+        margin: 0 20px 20px;
+      }
+
+      .submit-field {
+        margin: 0 20px 30px;
+
+        .btn {
+          display: block;
+          background-color: #094067;
+          color: #fffffe;
+          border-radius: 3px;
+          border: none;
+          cursor: pointer;
+        }
+      }
+    }
+
+    .area-delete {
+      margin: 50px 30px;
+
+      .headline {
+
+        .fa-trash-alt {
+          margin-right: 3px;
+        }
+
+        font-size: 24px;
+        margin-bottom: 30px;
+      }
+
+      .explanation {
+        font-size: 15px;
+        margin-bottom: 30px;
+      }
+
+      .delete-field {
+        text-align: center;
+
+        .btn {
+          display: block;
+          color: #fffffe;
+          background: #ef4565;
+          padding: 8px;
+          border-radius: 3px;
+          text-decoration: none;
+        }
+      }
+    }
+  }
+}

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -38,7 +38,11 @@ class Users::RegistrationsController < Devise::RegistrationsController
   #   super
   # end
 
-  # protected
+  protected
+
+  def update_resource(resource, params)
+    resource.update_without_password(params)
+  end
 
   # If you have extra params to permit, append them to the sanitizer.
   # def configure_sign_up_params

--- a/app/views/users/registrations/edit.html.erb
+++ b/app/views/users/registrations/edit.html.erb
@@ -1,68 +1,47 @@
-<div class="container-center">
-  <h2 class="user-auth__title">アカウントの編集</h2>
-  <div class="user-auth__form">
-    <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
-      <%= render "devise/shared/error_messages", resource: resource %>
+<div class="user-edit">
 
-      <div class="user-auth__form-img">
-        <%= image_tag @user.image.url, id: :js_img_prev , class: "icon" %>
-      </div>
+  <div class="user-edit__main">
+    <div class="form">
+      <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
+        <%= render "devise/shared/error_messages", resource: resource %>
 
-      <div class="user-auth__form-field">
-        <%= f.label :image, "プロフィール画像を変更", class: "image-btn" %>
-        <%= f.file_field :image, accept: "image/png,image/jpeg,image/gif", class: "image-form" %>
-      </div>
+        <div class="area-image">
+          <%= image_tag @user.image.url, id: :js_img_prev , class: "icon" %>
+        </div>
 
-      <div class="user-auth__form-field">
-        <%= f.label :name %><br />
-        <%= f.text_field :name, autofocus: true, autocomplete: "name", placeholder: "ユーザ名", required: true, maxlength: '10' %>
-      </div>
+        <div class="image-field">
+          <%= f.label :image, "プロフィール画像を変更", class: "btn" %>
+          <%= f.file_field :image, accept: "image/png,image/jpeg,image/gif" %>
+        </div>
 
-      <div class="user-auth__form-field">
-        <%= f.label :profile %><br />
-        <%= f.text_area :profile, autocomplete: "profile", size: '30x10', placeholder: "プロフィール", maxlength: '200' %>
-      </div>
+        <div class="name-field">
+          <%= f.label :name %>
+          <%= f.text_field :name, autofocus: true, autocomplete: "name", placeholder: "ユーザ名", required: true, maxlength: '10' %>
+        </div>
 
-      <div class="user-auth__form-field">
-        <%= f.label :email %><br />
-        <%= f.email_field :email, autofocus: true, autocomplete: "email", placeholder: "メールアドレス", required: true, maxlength: '100' %>
-      </div>
+        <div class="profile-field">
+          <%= f.label :profile %>
+          <%= f.text_area :profile, autocomplete: "profile", size: '30x10', placeholder: "プロフィール", maxlength: '200' %>
+        </div>
 
-      <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
-        <div><%= t('.currently_waiting_confirmation_for_email', email: resource.unconfirmed_email) %></div>
+        <div class="submit-field">
+          <%= f.submit "更新する", class: "btn" %>
+        </div>
       <% end %>
-
-      <div class="user-auth__form-field">
-        <%= f.label :password %> <i>(<%= t('.leave_blank_if_you_don_t_want_to_change_it') %>)</i><br />
-        <%= f.password_field :password, autocomplete: "new-password", placeholder: "新しいパスワード", maxlength: '30' %>
-        <% if @minimum_password_length %>
-          <br />
-          <em><%= t('devise.shared.minimum_password_length', count: @minimum_password_length) %></em>
-        <% end %>
-      </div>
-
-      <div class="user-auth__form-field">
-        <%= f.label :password_confirmation %><br />
-        <%= f.password_field :password_confirmation, autocomplete: "new-password", placeholder: "新しいパスワード(確認用)" %>
-      </div>
-
-      <div class="user-auth__form-field">
-        <%= f.label :current_password %> <i>(<%= t('.we_need_your_current_password_to_confirm_your_changes') %>)</i><br />
-        <%= f.password_field :current_password, autocomplete: "current-password", placeholder: "現在のパスワード" %>
-      </div>
-
-      <div class="actions">
-        <%= f.submit t('.update'), class: "btn" %>
-      </div>
-    <% end %>
-
-    <h3><%= t('.cancel_my_account') %></h3>
-
-    <div>
-      <%= link_to "トップページ", root_path %>
-      <%= link_to t('.cancel_my_account'), registration_path(resource_name), data: {confirm: t('.are_you_sure')}, method: :delete %>
     </div>
 
-    <%= link_to t('devise.shared.links.back'), :back %>
+    <hr>
+
+    <div class="area-delete">
+      <h2 class="headline"><i class="fas fa-trash-alt"></i>アカウント削除</h2>
+      <p class="explanation">
+        一度アカウントを削除すると、二度と元に戻せません。<br>
+        十分ご注意ください。
+      </p>
+      <div class="delete-field">
+        <%= link_to t('.cancel_my_account'), registration_path(resource_name), data: {confirm: t('.are_you_sure')}, method: :delete, class: "btn" %>
+      </div>
+    </div>
   </div>
+
 </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -7,7 +7,7 @@
 
   <% if @user == current_user %>
   <div class="area__button">
-    <%= link_to 'プロフィールを編集', edit_user_registration_path, class: "edit" %>
+    <%= link_to 'プロフィールを編集', edit_user_registration_path, class: "btn" %>
   </div>
   <% end %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   root "homes#index"
-  devise_for :users
+  devise_for :users, controllers: { registrations: "users/registrations" }
   resources :posts
   resources :users, only: :show
 end


### PR DESCRIPTION
## 概要
プロフィール画面とプロフィール変更画面のレイアウトを変更

### 内容
- プロフィール画面を作成しレイアウトを変更
- プロフィール変更画面のレイアウトを変更
- プロフィール画面を変更する際にパスワード入力なしで変更できるように実装

#### 備考

- ワイルドカードを使用して`users`ディレクトリと`posts`ディレクトリ配下の`scss`ファイルを読み込むように変更