### PR TITLE
deviseのURLをカスタム

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,5 +8,5 @@ class User < ApplicationRecord
   validates :profile, length: { maximum: 200 }
   mount_uploader :image, ImageUploader
 
-  has_many :posts
+  has_many :posts, :dependent => :destroy
 end

--- a/app/views/users/passwords/edit.html.erb
+++ b/app/views/users/passwords/edit.html.erb
@@ -1,6 +1,6 @@
 <h2><%= t('.change_your_password') %></h2>
 
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
+<%= form_for(resource, as: resource_name, url: update_user_password_path, html: { method: :put }) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
   <%= f.hidden_field :reset_password_token %>
 

--- a/app/views/users/passwords/new.html.erb
+++ b/app/views/users/passwords/new.html.erb
@@ -1,6 +1,6 @@
 <h2><%= t('.forgot_your_password') %></h2>
 
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
+<%= form_for(resource, as: resource_name, url: new_user_password_path, html: { method: :post }) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
 
   <div class="field">

--- a/app/views/users/registrations/edit.html.erb
+++ b/app/views/users/registrations/edit.html.erb
@@ -2,7 +2,7 @@
 
   <div class="user-edit__main">
     <div class="form">
-      <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
+      <%= form_for(resource, as: resource_name, url: update_user_registration_path, html: { method: :put }) do |f| %>
         <%= render "devise/shared/error_messages", resource: resource %>
 
         <div class="area-image">
@@ -39,7 +39,7 @@
         十分ご注意ください。
       </p>
       <div class="delete-field">
-        <%= link_to t('.cancel_my_account'), registration_path(resource_name), data: {confirm: t('.are_you_sure')}, method: :delete, class: "btn" %>
+        <%= link_to t('.cancel_my_account'), destroy_user_registration_path, data: {confirm: t('.are_you_sure')}, method: :delete, class: "btn" %>
       </div>
     </div>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
     get "signup" => "users/registrations#new", as: :new_user_registration
     post "signup" => "users/registrations#create", as: :user_registration
     get "signup/cancel" => "users/registrations#cancel", as: :cancel_user_registration
-    get "settings/profile" => "users/registrations#edit", as: :edit_user_registration
+    get "user" => "users/registrations#edit", as: :edit_user_registration
     patch "user" => "users/registrations#update", as: nil
     put "user" => "users/registrations#update", as: :update_user_registration
     delete "user" => "users/registrations#destroy", as: :destroy_user_registration

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,26 @@
 Rails.application.routes.draw do
   root "homes#index"
-  devise_for :users, controllers: { registrations: "users/registrations" }
-  resources :posts
+
+  devise_for :users, skip: :all
+  devise_scope :user do
+    get "login" => "users/sessions#new", as: :new_user_session
+    post "login" => "users/sessions#create", as: :user_session
+    delete "logout" => "users/sessions#destroy", as: :destroy_user_session
+    get "signup" => "users/registrations#new", as: :new_user_registration
+    post "signup" => "users/registrations#create", as: :user_registration
+    get "signup/cancel" => "users/registrations#cancel", as: :cancel_user_registration
+    get "settings/profile" => "users/registrations#edit", as: :edit_user_registration
+    patch "user" => "users/registrations#update", as: nil
+    put "user" => "users/registrations#update", as: :update_user_registration
+    delete "user" => "users/registrations#destroy", as: :destroy_user_registration
+    get "password" => "users/passwords#new", as: :new_user_password
+    post "password" => "users/passwords#create", as: :user_password
+    get "password/edit" => "users/passwords#edit", as: :edit_user_password
+    patch "password" => "users/passwords#update"
+    put "password" => "users/passwords#update", as: :update_user_password
+  end
+
   resources :users, only: :show
+
+  resources :posts
 end


### PR DESCRIPTION
### 概要
`devise`の`URL`をカスタム

### 内容
- `devise` の`URL` をデフォルトのものから変更。
- 退会時に投稿データを削除するように実装