### PR TITLE
アカウント削除ページを追加

### DIFF
--- a/app/assets/stylesheets/_base.scss
+++ b/app/assets/stylesheets/_base.scss
@@ -1,6 +1,7 @@
 body {
   background-color: #f8f5f2;
   font-family: 'ヒラギノ丸ゴ ProN', 'Hiragino Maru Gothic ProN', sans-serif;
+  line-height: 150%;
 }
 
 a {

--- a/app/assets/stylesheets/users/_user.deactivate.scss
+++ b/app/assets/stylesheets/users/_user.deactivate.scss
@@ -1,0 +1,41 @@
+.user-deactivate {
+  margin: 100px auto;
+  width: 690px;
+  padding: 15px;
+  background: white;
+
+  .title {
+    font-size: 45px;
+    padding: 30px;
+    margin-bottom: 50px;
+    border-bottom: 1px solid #5f6c7b;
+    text-align: center;
+  }
+
+  .explanation {
+    padding: 10px;
+    margin-bottom: 50px;
+  }
+
+  .delete-field {
+    width: 50%;
+    text-align: center;
+    margin: 0 auto;
+    margin-bottom: 50px;
+    font-size: 20px;
+
+    .btn {
+      display: block;
+      color: #fffffe;
+      background: #ef4565;
+      padding: 20px;
+      border-radius: 3px;
+      text-decoration: none;
+      margin-bottom: 50px;
+
+      .fa-user-slash {
+        margin-right: 5px;
+      }
+    }
+  }
+}

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -38,6 +38,12 @@ class Users::RegistrationsController < Devise::RegistrationsController
   #   super
   # end
 
+  def deactivate
+    unless user_signed_in?
+      redirect_to new_user_session_url, alert: "ログインしてください。"
+    end
+  end
+
   protected
 
   def update_resource(resource, params)

--- a/app/views/users/registrations/deactivate.html.erb
+++ b/app/views/users/registrations/deactivate.html.erb
@@ -1,0 +1,9 @@
+<h2>アカウント削除</h2>
+
+<div class="delete-field">
+  <%= link_to "アカウント削除", destroy_user_registration_path, data: {confirm: "アカウントを削除すると投稿内容が全て削除されます。\n本当によろしいですか？"}, method: :delete, class: "btn" %>
+</div>
+
+<ul>
+  <li><%= link_to "登録情報変更", edit_user_registration_path %></li>
+</ul>

--- a/app/views/users/registrations/deactivate.html.erb
+++ b/app/views/users/registrations/deactivate.html.erb
@@ -1,9 +1,19 @@
-<h2>アカウント削除</h2>
+<div class="user-deactivate">
+  <h2 class="title">退会する</h2>
 
-<div class="delete-field">
-  <%= link_to "アカウント削除", destroy_user_registration_path, data: {confirm: "アカウントを削除すると投稿内容が全て削除されます。\n本当によろしいですか？"}, method: :delete, class: "btn" %>
+  <p class="explanation">
+    退会処理を行うと、Snippetsでの内容（投稿内容やアカウント情報）が全て削除されます。<br>
+    この処理は取り消しできません。
+  </p>
+
+  <div class="delete-field">
+    <%= link_to destroy_user_registration_path, data: {confirm: "アカウントを削除すると投稿内容が全て削除されます。\n本当によろしいですか？"}, method: :delete, class: "btn" do %>
+      <%= icon('fas', 'user-slash') %>退会する
+    <% end %>
+    <%= link_to "キャンセル", edit_user_registration_path %>
+  </div>
+
+  <ul>
+    <li></li>
+  </ul>
 </div>
-
-<ul>
-  <li><%= link_to "登録情報変更", edit_user_registration_path %></li>
-</ul>

--- a/app/views/users/registrations/edit.html.erb
+++ b/app/views/users/registrations/edit.html.erb
@@ -39,7 +39,7 @@
         十分ご注意ください。
       </p>
       <div class="delete-field">
-        <%= link_to t('.cancel_my_account'), destroy_user_registration_path, data: {confirm: t('.are_you_sure')}, method: :delete, class: "btn" %>
+        <%= link_to "アカウント削除", deactivate_user_registration_path, class: "btn" %>
       </div>
     </div>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,7 @@ Rails.application.routes.draw do
     patch "user" => "users/registrations#update", as: nil
     put "user" => "users/registrations#update", as: :update_user_registration
     delete "user" => "users/registrations#destroy", as: :destroy_user_registration
+    get "deactivate" => "users/registrations#deactivate", as: :deactivate_user_registration
     get "password" => "users/passwords#new", as: :new_user_password
     post "password" => "users/passwords#create", as: :user_password
     get "password/edit" => "users/passwords#edit", as: :edit_user_password


### PR DESCRIPTION
## 概要
- `アカウント削除ページ`を追加

### 内容
- 新たに`アカウント削除ページ`を作成
- `アカウント編集ページ`から`アカウント削除ページ`への導線を追加
- `アカウント削除ページ`からアカウント削除処理を実装できるように変更
