### PR TITLE
パスワード変更画面を作成

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -38,6 +38,10 @@ class Users::RegistrationsController < Devise::RegistrationsController
   #   super
   # end
 
+  def change_password
+    @user = current_user
+  end
+
   def deactivate
     unless user_signed_in?
       redirect_to new_user_session_url, alert: "ログインしてください。"
@@ -47,7 +51,11 @@ class Users::RegistrationsController < Devise::RegistrationsController
   protected
 
   def update_resource(resource, params)
-    resource.update_without_password(params)
+    resource.update_without_current_password(params)
+  end
+
+  def after_update_path_for(resource)
+    user_path(@user.id)
   end
 
   # If you have extra params to permit, append them to the sanitizer.

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,4 +9,17 @@ class User < ApplicationRecord
   mount_uploader :image, ImageUploader
 
   has_many :posts, :dependent => :destroy
+
+  def update_without_current_password(params, *options)
+    params.delete(:current_password)
+
+    if params[:password].blank? && params[:password_confirmation].blank?
+      params.delete(:password)
+      params.delete(:password_confirmation)
+    end
+
+    result = update_attributes(params, *options)
+    clean_up_passwords
+    result
+  end
 end

--- a/app/views/users/registrations/change_password.html.erb
+++ b/app/views/users/registrations/change_password.html.erb
@@ -1,0 +1,33 @@
+<div class="container-center">
+  <h2 class="user-auth__title">パスワードを変更</h2>
+  <div class="user-auth__form">
+    <%= form_for(resource, as: resource_name, url: update_user_registration_path, html: { method: :put }) do |f| %>
+      <%= render "devise/shared/error_messages", resource: resource %>
+
+      <div class="user-auth__form-field">
+        <%= f.label :password %>
+        <%= f.password_field :password, autocomplete: "new-password", placeholder: "新しいパスワード", maxlength: '30' %>
+        <% if @minimum_password_length %>
+          <br />
+          <em><%= t('devise.shared.minimum_password_length', count: @minimum_password_length) %></em>
+        <% end %>
+      </div>
+
+      <div class="user-auth__form-field">
+        <%= f.label :password_confirmation %>
+        <%= f.password_field :password_confirmation, autocomplete: "new-password", placeholder: "新しいパスワード(確認用)" %>
+      </div>
+
+      <div class="user-auth__form-field">
+        <%= f.label :current_password %>
+        <%= f.password_field :current_password, autocomplete: "current-password", placeholder: "現在のパスワード" %>
+      </div>
+
+      <div class="actions">
+        <%= f.submit "変更する", class: "btn" %>
+      </div>
+    <% end %>
+
+    <%= link_to t('devise.shared.links.back'), :back %>
+  </div>
+</div>

--- a/app/views/users/registrations/edit.html.erb
+++ b/app/views/users/registrations/edit.html.erb
@@ -30,6 +30,8 @@
       <% end %>
     </div>
 
+    <%= link_to "パスワード変更", change_password_user_registration_path %>
+
     <hr>
 
     <div class="area-delete">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
     post "signup" => "users/registrations#create", as: :user_registration
     get "signup/cancel" => "users/registrations#cancel", as: :cancel_user_registration
     get "user" => "users/registrations#edit", as: :edit_user_registration
+    get "settings/password" => "users/registrations#change_password", as: :change_password_user_registration
     patch "user" => "users/registrations#update", as: nil
     put "user" => "users/registrations#update", as: :update_user_registration
     delete "user" => "users/registrations#destroy", as: :destroy_user_registration


### PR DESCRIPTION
## 概要
`パスワード変更画面`を作成

### 内容
- `アカウント編集画面`とは別で、`パスワード変更画面`を作成
- `パスワード変更画面`から、パスワード変更の更新処理が`DB`へ反映されるように実装
- アカウント更新とパスワード変更処理が完了後のリダイレクト先が、マイページになるように実装
