### PR TITLE
タブボタンで切り替えできるように実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,4 @@
 - redcarpet
 - coderay
 - impressionist
+- ransack

--- a/app/assets/stylesheets/posts/_post-show.scss
+++ b/app/assets/stylesheets/posts/_post-show.scss
@@ -94,6 +94,19 @@
 
   .right {
     float: right;
+
+    .fav {
+      font-size: 1.5em;
+      display: inline-block;
+      transition: .1s;
+      transform: scale(1);
+
+      &:hover {
+        text-decoration: none;
+        transform: scale(1.4);
+      }
+
+    }
   }
 
 }

--- a/app/assets/stylesheets/posts/_posts-index.scss
+++ b/app/assets/stylesheets/posts/_posts-index.scss
@@ -134,7 +134,6 @@
 
             &:hover {
               opacity: 0.5;
-              transition: .1s;
             }
           }
         }

--- a/app/assets/stylesheets/users/_user-show.scss
+++ b/app/assets/stylesheets/users/_user-show.scss
@@ -44,45 +44,97 @@
   }
 
   &__center {
-    margin: 0 auto;
-    width: 300px;
-    padding: 30px;
+    margin: auto;
+    width: 600px;
+    flex-wrap: wrap;
+    display: flex;
 
-    .area__posts {
-      margin-bottom: 50px;
+    input[name="hide"] {
+      display: none;
+    }
 
-      .headline {
-        font-size: 27px;
-        margin-bottom: 15px;
+    .tab {
+      width: calc(100%/2);
+      height: 50px;
+      line-height: 50px;
+      background-color: #d8eefe;
+      text-align: center;
+      order: -1;
+      cursor: pointer;
 
-        .fa-list {
-          color: #ef4565;
-          margin-right: 6px;
-        }
+      &:hover {
+        transition: .1s;
+        opacity: 0.9;
+        box-shadow: 0 0 .2em gray;
       }
 
-      .list {
-        font-size: 20px;
-        margin-bottom: 10px;
+      i {
+        margin-right: 0.5em;
       }
     }
 
-    .area__favorites {
-      .headline {
-        font-size: 27px;
-        margin-bottom: 15px;
+    input:checked+.tab {
+      background-color: #094067;
+      color: #fffffe;
+    }
 
-        .fa-thumbs-up {
-          color: #ef4565;
-          margin-right: 6px;
-        }
-      }
+    .content {
+      display: none;
+      width: 100%;
+      margin-top: 2em;
 
       .list {
-        font-size: 20px;
-        margin-bottom: 10px;
+
+        .item {
+          padding: 15px;
+          border-top: 1px solid #6665658f;
+          display: flex;
+          align-items: center;
+
+          .area-image {
+            margin-right: 1em;
+
+            .icon {
+              width: 50px;
+              height: 50px;
+              border-radius: 50%;
+              box-shadow: 0 0 3px gray;
+
+              &:hover {
+                opacity: 0.8;
+                transition: .1s;
+              }
+            }
+          }
+
+          .area-body {
+            .title {
+              font-size: 1.1em;
+
+              .link {
+                color: #232323;
+              }
+            }
+
+            .details {
+              color: #8c9aaa;
+              font-size: 0.8em;
+
+              .date-time {
+                margin-right: 1em;
+              }
+
+              .view {
+                margin-right: 0.3em;
+              }
+            }
+          }
+        }
       }
+    }
+
+    input:checked+.tab+.content {
+      display: block;
     }
   }
-
 }

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,7 +1,7 @@
 class UsersController < ApplicationController
   def show
     @user = User.find(params[:id])
-    @posts = @user.posts
-    @favorite_posts = @user.favorite_posts
+    @posts = @user.posts.order(created_at: :desc)
+    @favorite_posts = @user.favorite_posts.order(created_at: :desc)
   end
 end

--- a/app/views/favorites/_favorite.html.erb
+++ b/app/views/favorites/_favorite.html.erb
@@ -1,11 +1,11 @@
 <% if @post.favorited_by?(current_user) %>
-  <%= link_to post_favorites_path(@post.id), method: :delete, remote: true do %>
-    <%= icon('fas', 'thumbs-up') %>
+  <%= link_to post_favorites_path(@post.id), method: :delete, remote: true, class: "fav" do %>
+    <%= icon('fas', 'thumbs-up', class: 'fa-fw') %>
   <% end %>
   <span><%= @post.favorites.count %></span>
 <% else %>
-  <%= link_to post_favorites_path(@post.id), method: :post, remote: true do %>
-    <%= icon('far', 'thumbs-up') %>
+  <%= link_to post_favorites_path(@post.id), method: :post, remote: true, class: "fav" do %>
+    <%= icon('far', 'thumbs-up', class: 'fa-fw') %>
   <% end %>
   <span><%= @post.favorites.count %></span>
 <% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -13,20 +13,51 @@
 </div>
 
 <div class="user-show__center">
-  <div class="area__posts">
-    <div class="headline"><%= icon('fas', 'list') %>投稿一覧</div>
-    <% @posts.each do |post| %>
-      <div class="list">
-        <%= link_to post.title, post %>
-      </div>
-    <% end %>
+  <input type="radio" name="hide" id="tab1" checked>
+  <label class="tab" for="tab1"><%= icon('fas', 'list') %>投稿一覧</label>
+  <div class="content">
+    <div class="list">
+      <% @posts.each do |post| %>
+          <div class="item">
+            <div class="area-image">
+              <%= link_to (image_tag post.user.image.url, class: "icon"), user_path(post.user_id) %>
+            </div>
+            <div class="area-body">
+              <div class="title">
+                <%= link_to post.title.truncate(50), post, class: "link" %>
+              </div>
+              <div class="details">
+                <span class="date-time"><%= icon('fas', 'paper-plane') %><%= time_ago_in_words post.created_at %>前</span>
+                <span class="view"><%= icon('far', 'eye') %><%= post.impressionist_count %></span>
+                <span class="favorite"><%= icon('far', 'thumbs-up') %><%= post.favorites.count %></span>
+              </div>
+            </div>
+          </div>
+      <% end %>
+    </div>
   </div>
-  <div class="area__favorites">
-    <div class="headline"><%= icon('fas', 'thumbs-up') %>いいね済</div>
-    <% @favorite_posts.each do |post| %>
-      <div class="list">
-        <%= link_to post.title, post %>
-      </div>
-    <% end %>
+
+  <input type="radio" name="hide" id="tab2" >
+  <label class="tab" for="tab2"><%= icon('fas', 'thumbs-up') %>いいね済</label>
+  <div class="content">
+    <div class="list">
+      <% @favorite_posts.each do |post| %>
+        <div class="item">
+          <div class="area-image">
+            <%= link_to (image_tag post.user.image.url, class: "icon"), user_path(post.user_id) %>
+          </div>
+          <div class="area-body">
+            <div class="title">
+              <%= link_to post.title.truncate(50), post, class: "link" %>
+            </div>
+            <div class="details">
+              <span class="date-time"><%= icon('fas', 'paper-plane') %><%= time_ago_in_words post.created_at %>前</span>
+              <span class="view"><%= icon('far', 'eye') %><%= post.impressionist_count %></span>
+              <span class="favorite"><%= icon('far', 'thumbs-up') %><%= post.favorites.count %></span>
+            </div>
+          </div>
+        </div>
+      <% end %>
+    </div>
   </div>
 </div>


### PR DESCRIPTION
## 概要
タブボタンで切り替えできるように実装

### 内容
- プロフィール画面の `投稿一覧` と `いいね済` をタブで切り替えできるように実装
- 一覧表示のレイアウトを変更
- 一覧表示時に、投稿日の降順で表示できるように変更
