### PR TITLE
フォロー済とフォロワーのリスト表示

### DIFF
--- a/app/assets/stylesheets/users/_user-show.scss
+++ b/app/assets/stylesheets/users/_user-show.scss
@@ -97,7 +97,7 @@
     }
 
     .tab {
-      width: calc(100%/2);
+      width: calc(100%/4);
       height: 50px;
       line-height: 50px;
       background-color: #d8eefe;
@@ -125,6 +125,11 @@
       display: none;
       width: 100%;
       margin-top: 2em;
+
+      .count {
+        text-align: center;
+        margin-bottom: 0.5em;
+      }
 
       .list {
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,5 +3,7 @@ class UsersController < ApplicationController
     @user = User.find(params[:id])
     @posts = @user.posts.order(created_at: :desc)
     @favorite_posts = @user.favorite_posts.order(created_at: :desc)
+    @followings = @user.followings
+    @followers = @user.followers
   end
 end

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -22,8 +22,11 @@
 
 <div class="user-show__center">
   <input type="radio" name="hide" id="tab1" checked>
-  <label class="tab" for="tab1"><%= icon('fas', 'list') %>投稿一覧</label>
+  <label class="tab" for="tab1"><%= icon('fas', 'th-list') %>投稿一覧</label>
   <div class="content">
+    <div class="count">
+      <%= @posts.count %>件
+    </div>
     <div class="list">
       <% @posts.each do |post| %>
           <div class="item">
@@ -48,6 +51,9 @@
   <input type="radio" name="hide" id="tab2" >
   <label class="tab" for="tab2"><%= icon('fas', 'thumbs-up') %>いいね済</label>
   <div class="content">
+    <div class="count">
+      <%= @favorite_posts.count %>件
+    </div>
     <div class="list">
       <% @favorite_posts.each do |post| %>
         <div class="item">
@@ -62,6 +68,56 @@
               <span class="date-time"><%= icon('fas', 'paper-plane') %><%= time_ago_in_words post.created_at %>前</span>
               <span class="view"><%= icon('far', 'eye') %><%= post.impressionist_count %></span>
               <span class="favorite"><%= icon('far', 'thumbs-up') %><%= post.favorites.count %></span>
+            </div>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  </div>
+
+  <input type="radio" name="hide" id="tab3" >
+  <label class="tab" for="tab3"><%= icon('fas', 'user-check') %>フォロー済</label>
+  <div class="content">
+    <div class="count">
+      <%= @followings.count %>人
+    </div>
+    <div class="list">
+      <% @followings.each do |user| %>
+        <div class="item">
+          <div class="area-image">
+            <%= link_to (image_tag user.image.url, class: "icon"), user_path(user.id) %>
+          </div>
+          <div class="area-body">
+            <div class="title">
+              <%= link_to user.name, user, class: "link" %>
+            </div>
+            <div class="details">
+              <%= user.profile %>
+            </div>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  </div>
+
+  <input type="radio" name="hide" id="tab4" >
+  <label class="tab" for="tab4"><%= icon('fas', 'user-friends') %>フォロワー</label>
+  <div class="content">
+    <div class="count">
+      <%= @followers.count %>人
+    </div>
+    <div class="list">
+      <% @followers.each do |user| %>
+        <div class="item">
+          <div class="area-image">
+            <%= link_to (image_tag user.image.url, class: "icon"), user_path(user.id) %>
+          </div>
+          <div class="area-body">
+            <div class="title">
+              <%= link_to user.name, user, class: "link" %>
+            </div>
+            <div class="details">
+              <%= user.profile %>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## 概要
ユーザーのフォロー済とフォロワーをリスト表示できるように実装

### 内容
- ユーザーのプロフィール画面に、フォロー済みとフォロワーをリスト表示するように実装

#### 備考
ユーザーのプロフィール画面に、
`投稿数`と`いいね数`と`フォロー済み数`と`フォロワー数`の合計数を表示